### PR TITLE
Remove artifact creation from ci_test

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -22,7 +22,3 @@ jobs:
           CONTACT_MANAGER_ENDPOINT: "https://icv8e1h418.execute-api.eu-west-1.amazonaws.com/dev/process-contact-form"
         with:
           args: --minify
-
-      - uses: actions/upload-artifact@v2
-        with:
-            path: './public'


### PR DESCRIPTION
Just don't compile a artifact during the test work flow and only when in a PR