### PR TITLE
Fix invalidation for master

### DIFF
--- a/.github/workflows/ci_master.yml
+++ b/.github/workflows/ci_master.yml
@@ -56,4 +56,4 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id E3Q248S6PCUHON \
-            --paths "/index.html"
+            --paths "/*"


### PR DESCRIPTION
This wil invalidate all the paths in the cloudfront distribution for master. Keep in mind that the invalidation's make incurrur on additional costs depending on the frequency.

https://docs.aws.amazon.com/es_es/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html